### PR TITLE
Chunks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ add_executable(archea
         systems/particle_types/WaterParticle_Type.h
         systems/ParticleData.cpp
         systems/ParticleData.h
+        systems/ParticlesChunk.cpp
+        systems/ParticlesChunk.h
+        systems/Shapes.h
 )
 # Run the copy_shaders commands
 add_dependencies(archea copy_shaders)

--- a/shaders/fragment.glsl
+++ b/shaders/fragment.glsl
@@ -163,7 +163,7 @@ vec4 getParticle(ivec3 c) {
     uint arraySize = ChunkSize; // make this a uniform
 
     // Ground
-    if (c.y == -1 && c.x >= 0 && c.z >= 0   && c.z < arraySize && c.x < arraySize) return vec4(vec3(0.3), 0.6);
+    // if (c.y == -1 && c.x >= 0 && c.z >= 0   && c.z < arraySize && c.x < arraySize) return vec4(vec3(0.3), 0.6);
 
     // Array index range checks
     if (c.x >= arraySize) return NoParticle;
@@ -294,23 +294,25 @@ void main() {
             color.rgb *= vec3(0.75);
         }
     } else {
+        if (!somethingHit) {
+            discard;
+        }
         // "Sky" color
         vec4 tempColor = vec4(0.3, 0.4, 0.4, 1.0);
         float forwardAlphaInv = 1.0 - color.a;
         color.rgb += tempColor.rgb * (tempColor.a * forwardAlphaInv);
         color.a = 1.0 - forwardAlphaInv * (1.0 - tempColor.a);
 
-        gl_FragDepth = 0.0;
         FragColor = color;
         return;
     }
 
     // Depth Buffer
     // -- https://stackoverflow.com/a/29397319/6079328
-    vec4 vClipCoord = projection * view * model * vec4(firstHitMapPos, 1.0);
-    float fNdcDepth = vClipCoord.z / vClipCoord.w;
-    //                                          vvv This should be 1.0 but if it is then particles go away when close
-    gl_FragDepth = color.a > 0.0 ? (fNdcDepth + 0.9) * 0.5 : DEPTH_FAR_AWAY;
+    //    vec4 vClipCoord = projection * view * model * vec4(firstHitMapPos, 1.0);
+    //    float fNdcDepth = vClipCoord.z / vClipCoord.w;
+    //    //                                          vvv This should be 1.0 but if it is then particles go away when close
+    //    gl_FragDepth = color.a > 0.0 ? (fNdcDepth + 0.9) * 0.5 : DEPTH_FAR_AWAY;
 
     FragColor = color;
 }

--- a/systems/ParticlesChunk.cpp
+++ b/systems/ParticlesChunk.cpp
@@ -10,8 +10,6 @@
 #include <fstream>
 #include <cstring>  // for memcpy
 #include <cstddef> // for std::byte
-#include <bit>
-#include <semaphore>
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
@@ -100,6 +98,7 @@ ParticlesChunk::ParticlesChunk(
 }
 
 ParticlesChunk::~ParticlesChunk() {
+    const std::lock_guard guard(lock);
     SaveChunkData();
 }
 
@@ -123,9 +122,13 @@ void ParticlesChunk::ProcessNextSimulationStep() {
             for (unsigned z = 0; z < chunkParticleGridSize.z; ++z) {
                 const auto currentPos = glm::ivec3(x, y, z);
 
+                if (!particleManager.Exists(currentPos)) {
+                    continue;
+                }
+
                 // z * (ysize * xsize) + y * (xsize) + x
                 unsigned particle = particleManager.Get(currentPos).particleType;
-                if (particle <= 1) continue;
+                // if (particle <= 1) continue;
 
                 auto particleTypeInfo = ParticleTypeSystem::GetParticleTypeInfo(particle - 1);
 

--- a/systems/ParticlesChunk.cpp
+++ b/systems/ParticlesChunk.cpp
@@ -1,0 +1,281 @@
+//
+// Created by jonah on 9/7/2024.
+//
+
+#include "ParticlesChunk.h"
+
+#include <vector>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <cstring>  // for memcpy
+#include <cstddef> // for std::byte
+#include <bit>
+#include <semaphore>
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/gtc/type_ptr.hpp>
+
+#include "CameraSystem.h"
+#include "InputSystem.h"
+#include "particle_types/ParticleMove.h"
+#include "particle_types/ParticleType.h"
+#include "particle_types/ParticleTypeSystem.h"
+
+namespace PositionConversion
+{
+    glm::ivec3 WorldPositionToChunkPosition(
+        const glm::vec3& worldPosition,
+        const glm::uvec3& standardChunkSize
+    ) {
+        return worldPosition / glm::vec3(standardChunkSize);
+    }
+
+    glm::ivec3 WorldPositionToParticleGrid(
+        const glm::vec3& worldPosition,
+        float standardParticleScale
+    ) {
+        return worldPosition / standardParticleScale;
+    }
+
+    glm::ivec3 ParticleGridToChunkGrid(
+        const glm::ivec3& particlePosition,
+        const glm::uvec3& standardChunkParticleGridSize
+    ) {
+        return particlePosition / glm::ivec3(standardChunkParticleGridSize);
+    }
+}
+
+ParticlesChunk::ParticlesChunk(
+    const glm::ivec3& chunkGridPosition,
+    const glm::uvec3& particleGridSize,
+    float particleScale
+) : particleScale(particleScale),
+    worldPosition(),
+    chunkGridPosition(chunkGridPosition),
+    worldChunkScale(),
+    chunkParticleGridSize(particleGridSize),
+    particleManager(particleGridSize)
+{
+    worldChunkScale = glm::vec3(particleGridSize) * particleScale;
+    worldPosition = glm::vec3(chunkGridPosition) * worldChunkScale;
+
+    glCreateBuffers(1, &particlesBuffer);
+
+    glNamedBufferStorage(
+        particlesBuffer,
+        sizeof(int) * particleManager.GetCubicSize(),
+        static_cast<const void*>(particleManager.GetParticleTypesData().data()),
+        GL_DYNAMIC_STORAGE_BIT
+    );
+
+    if (!LoadChunkData())
+    {
+        // todo: Temp, for testing
+        for (unsigned x = 10; x < 20; ++x) {
+            for (unsigned y = 5; y < 15; ++y) {
+                for (unsigned z = 10; z < 20; ++z) {
+                    particleManager.SetType(glm::uvec3(x, y, z), 2);
+                }
+            }
+        }
+    }
+}
+
+ParticlesChunk::~ParticlesChunk() {
+    SaveChunkData();
+}
+
+void ParticlesChunk::Update(float dt) {
+    if (dt == 0.0f) return;
+
+    // todo: use this to load/unload chunks
+    // const glm::ivec3 currentChunk = PositionConversion::WorldPositionToChunkPosition(CameraSystem::GetPosition(), chunkParticleGridSize);
+    // if (glm::distance(glm::vec3(currentChunk), glm::vec3(chunkGridPosition)) >= 2.0f) {
+    //     // Do something
+    // }
+}
+
+void ParticlesChunk::ProcessNextSimulationStep() {
+    const std::lock_guard guard(lock);
+
+    for (unsigned x = 0; x < chunkParticleGridSize.x; ++x) {
+        for (int y = 0; y < chunkParticleGridSize.y; ++y) {
+            for (unsigned z = 0; z < chunkParticleGridSize.z; ++z) {
+                const auto currentPos = glm::ivec3(x, y, z);
+
+                // z * (ysize * xsize) + y * (xsize) + x
+                unsigned particle = particleManager.Get(currentPos).particleType;
+                if (particle <= 1) continue;
+
+                auto particleTypeInfo = ParticleTypeSystem::GetParticleTypeInfo(particle - 1);
+
+                auto posToTry = glm::ivec3(0);
+
+                // new
+                auto nextMove = ParticleMove::MoveState {};
+                while (true) {
+                    particleTypeInfo.getNextMove(nextMove);
+
+                    if (nextMove.done) break;
+
+                    posToTry = currentPos + glm::ivec3(nextMove.positionToTry);
+
+                    // try pos
+
+                    if (posToTry.y < 0) continue;
+                    posToTry = glm::clamp(posToTry, glm::ivec3(0), glm::ivec3(49));
+                    // int newY = std::clamp<int>(y - 1, 0, 49);
+
+                    unsigned atNewPos = particleManager.Get(posToTry).particleType;
+                    if (atNewPos != 0) continue;
+
+                    // We are here, we are allowed to move here
+
+                    particleManager.SetType(posToTry, particle);
+                    // remove
+                    particleManager.SetType(glm::uvec3(x, y, z), 0);
+                    break;
+                    // if works, break
+                    // else continue
+                }
+                //end
+            }
+        }
+    }
+}
+
+void ParticlesChunk::Render(
+    GLFWwindow* window,
+    GLuint shaderProgram,
+    GLuint particlesColorsBuffer,
+    GLuint VAO
+) {
+    glNamedBufferSubData(
+        particlesBuffer,
+        0,
+        sizeof(int) * particleManager.GetCubicSize(),
+        static_cast<const void*>(particleManager.GetParticleTypesData().data())
+    );
+
+    // Bind the particles data
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, particlesBuffer);
+    // Bind the particles color data
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, particlesColorsBuffer);
+
+    // Set the shader program
+    glUseProgram(shaderProgram);
+
+    int width, height;
+    glfwGetFramebufferSize(window, &width, &height);
+    // glUniform2f(glGetUniformLocation(shaderProgram, "Resolution"), width, height);
+    glUniform1f(glGetUniformLocation(shaderProgram, "Time"), static_cast<float>(glfwGetTime()));
+
+    auto cameraFieldOfView = CameraSystem::GetFOV();
+    auto cameraPos = CameraSystem::GetPosition();
+    auto cameraMatrix = CameraSystem::CameraMatrix();
+    // glUniform1f(glGetUniformLocation(shaderProgram, "FieldOfView"), cameraFieldOfView);
+    glUniform3f(glGetUniformLocation(shaderProgram, "CameraPosition"), cameraPos.x, cameraPos.y, cameraPos.z);
+    // glUniformMatrix4fv(glGetUniformLocation(shaderProgram, "CameraView"), 1, GL_FALSE, glm::value_ptr(cameraMatrix));
+
+    // Pass the matrices to the shader (for vertex shader for now)
+    GLuint modelLoc = glGetUniformLocation(shaderProgram, "model");
+    GLuint viewLoc = glGetUniformLocation(shaderProgram, "view");
+    GLuint projectionLoc = glGetUniformLocation(shaderProgram, "projection");
+    auto model = glm::translate(CameraSystem::GetModel(), worldPosition);
+    auto view = CameraSystem::GetView();
+    auto projection = CameraSystem::GetProjection();
+    glUniformMatrix4fv(modelLoc, 1, GL_FALSE, glm::value_ptr(model));
+    glUniformMatrix4fv(viewLoc, 1, GL_FALSE, glm::value_ptr(view));
+    glUniformMatrix4fv(projectionLoc, 1, GL_FALSE, glm::value_ptr(projection));
+
+    glUniform1i(glGetUniformLocation(shaderProgram, "MAX_RAY_STEPS"), ChunkConfig::maxRaySteps);
+    glUniform1f(glGetUniformLocation(shaderProgram, "ParticleScale"), particleScale);
+    glUniform1ui(glGetUniformLocation(shaderProgram, "EnableOutlines"), ChunkConfig::enableOutlines);
+    // Fixme, chunksize xyz is no longer garenteed to be the same
+    glUniform1ui(glGetUniformLocation(shaderProgram, "ChunkSize"), chunkParticleGridSize.x);
+
+    // Bind the vertex data
+    glBindVertexArray(VAO);
+    // Call draw
+    glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, 0);
+
+    // glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, 0);
+}
+
+bool ParticlesChunk::TryPlaceParticleAt(
+    const glm::ivec3& worldParticlePosition,
+    const ParticleData::DataWrapper& particleDataWraper
+)
+{
+    const glm::ivec3 chunkPos = PositionConversion::ParticleGridToChunkGrid(worldParticlePosition, chunkParticleGridSize);
+    if (chunkPos != chunkGridPosition) {
+        return false;
+    }
+
+    // Block until able to aquire lock
+    const std::lock_guard guard(lock);
+
+    const glm::uvec3 particlePositionInChunk = glm::abs(worldParticlePosition - (chunkGridPosition * glm::ivec3(chunkParticleGridSize)));
+
+    particleManager.SetType(particlePositionInChunk, particleDataWraper.particleType);
+
+    return false;
+}
+
+bool ParticlesChunk::SaveChunkData()
+{
+    std::stringstream filenameForChunk;
+    filenameForChunk
+    << "chunks/"
+    << chunkGridPosition.x
+    << "-"
+    << chunkGridPosition.y
+    << "-"
+    << chunkGridPosition.z
+    << ".bin";
+
+    std::vector<std::byte> bytes(sizeof(unsigned) * particleManager.GetParticleTypesData().size());
+    std::memcpy(bytes.data(), particleManager.GetParticleTypesData().data(), sizeof(unsigned) * particleManager.GetParticleTypesData().size());
+
+    std::ofstream file(filenameForChunk.str(), std::ios::binary);
+    if (file) {
+        file.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    }
+    file.close();
+
+    return true;
+}
+
+bool ParticlesChunk::LoadChunkData()
+{
+    try {
+        std::stringstream filenameForChunk;
+        filenameForChunk
+        << "chunks/"
+        << chunkGridPosition.x
+        << "-"
+        << chunkGridPosition.y
+        << "-"
+        << chunkGridPosition.z
+        << ".bin";
+
+        std::ifstream file(filenameForChunk.str(), std::ios::binary);
+
+        if (file) {
+            file.read(
+                reinterpret_cast<char*>( const_cast<unsigned*>(particleManager.GetParticleTypesData().data()) ),
+                sizeof(unsigned) * 50 * 50 * 50
+            );
+        } else {
+            file.close();
+            return false;
+        }
+        file.close();
+
+        return true;
+    } catch (std::exception& e) {
+        return false;
+    }
+}

--- a/systems/ParticlesChunk.cpp
+++ b/systems/ParticlesChunk.cpp
@@ -87,14 +87,16 @@ ParticlesChunk::~ParticlesChunk() {
     SaveChunkData();
 }
 
-void ParticlesChunk::Update(float dt) {
-    if (dt == 0.0f) return;
+bool ParticlesChunk::Update(float dt) {
+    if (dt == 0.0f) return true;
 
     // todo: use this to load/unload chunks
     // const glm::ivec3 currentChunk = PositionConversion::WorldPositionToChunkPosition(CameraSystem::GetPosition(), chunkParticleGridSize);
     // if (glm::distance(glm::vec3(currentChunk), glm::vec3(chunkGridPosition)) >= 2.0f) {
     //     // Do something
     // }
+
+    return true;
 }
 
 void ParticlesChunk::ProcessNextSimulationStep() {
@@ -264,6 +266,8 @@ bool ParticlesChunk::LoadChunkData()
         std::ifstream file(filenameForChunk.str(), std::ios::binary);
 
         if (file) {
+            std::cout << "Reading: " << filenameForChunk.str() << std::endl;
+
             file.read(
                 reinterpret_cast<char*>( const_cast<unsigned*>(particleManager.GetParticleTypesData().data()) ),
                 sizeof(unsigned) * 50 * 50 * 50
@@ -278,4 +282,12 @@ bool ParticlesChunk::LoadChunkData()
     } catch (std::exception& e) {
         return false;
     }
+}
+
+glm::vec3 ParticlesChunk::getChunkDistanceFrom(const glm::ivec3 &chunkPos) {
+    return chunkPos - this->chunkGridPosition;
+}
+
+glm::ivec3 ParticlesChunk::getChunkWorldPosition() {
+    return this->chunkGridPosition;
 }

--- a/systems/ParticlesChunk.cpp
+++ b/systems/ParticlesChunk.cpp
@@ -73,14 +73,30 @@ ParticlesChunk::ParticlesChunk(
     if (!LoadChunkData())
     {
         // todo: Temp, for testing
-        for (unsigned x = 10; x < 20; ++x) {
+        for (unsigned x = 10; x < 25; ++x) {
             for (unsigned y = 5; y < 15; ++y) {
-                for (unsigned z = 10; z < 20; ++z) {
+                for (unsigned z = 10; z < 25; ++z) {
                     particleManager.SetType(glm::uvec3(x, y, z), 2);
                 }
             }
         }
     }
+
+    // Should probably use a thread pool and pass these in as scheduled work or something
+//    using namespace std::chrono_literals;
+//    static auto stepDelay = 1000ms;
+//    simulationThread = std::jthread([this]() {
+//        while (true) {
+//            this->ProcessNextSimulationStep();
+//
+//            // const auto start = std::chrono::high_resolution_clock::now();
+//            std::this_thread::sleep_for(stepDelay);
+//            // const auto end = std::chrono::high_resolution_clock::now();
+//            // const std::chrono::duration<double, std::milli> elapsed = end - start;
+//
+//            // std::cout << "Waited " << elapsed.count() << '\n';
+//        }
+//    });
 }
 
 ParticlesChunk::~ParticlesChunk() {

--- a/systems/ParticlesChunk.h
+++ b/systems/ParticlesChunk.h
@@ -1,0 +1,80 @@
+//
+// Created by jonah on 9/7/2024.
+//
+
+
+#pragma once
+#include <mutex>
+#include <GL/glew.h>
+
+#include "ParticleData.h"
+#include <glm/glm.hpp>
+
+#include "ImGuiSystem.h"
+#include "InputSystem.h"
+
+/*
+ * What is a chunk responsible for doing?
+ * A chunk keeps track of the particles within it: this means each chunk will have a ParticleData::Manager
+ * A chunk is responsible for rendering the particles within it.
+ * - It is not responsible for render order, or weather it should be rendered.
+ * - Chunks should only render something when they are told to
+ * A chunk must update the next state of particles when it is told to do so
+ * A chunk is responsible for saving particle data on destruction
+ * A chunk is responsible for loading particle data associated with it's position upon creation
+ * Chunks need to be thread safe. They must be able to function within their own thread.
+ * Reasons chunks would need to access another chunk:
+ * - A particle moves outside of the chunk
+ * ! Access to other chunks could be problematic for thread safety
+ */
+
+namespace PositionConversion
+{
+    glm::ivec3 WorldPositionToChunkPosition(const glm::vec3& worldPosition, const glm::uvec3& standardChunkSize);
+
+    glm::ivec3 WorldPositionToParticleGrid(const glm::vec3& worldPosition, float standardParticleScale);
+
+    glm::ivec3 ParticleGridToChunkGrid(const glm::ivec3& particlePosition, const glm::uvec3& standardChunkParticleGridSize);
+}
+
+namespace ChunkConfig {
+    static int maxRaySteps = 200;
+    static bool enableOutlines = false;
+}
+
+class ParticlesChunk {
+public:
+    ParticlesChunk(
+        const glm::ivec3& chunkGridPosition,
+        const glm::uvec3& particleGridSize,
+        float particleScale
+    );
+
+    ~ParticlesChunk();
+
+    // Update must have a really small workload
+    void Update(float dt);
+    // todo: rename this?
+    void ProcessNextSimulationStep();
+    void Render(GLFWwindow* window, GLuint shaderProgram, GLuint particlesColorsBuffer, GLuint VAO);
+
+    // If the chunk has a lock on it's data, this will block until it's done
+    bool TryPlaceParticleAt(const glm::ivec3& worldParticlePosition, const ParticleData::DataWrapper& particleDataWraper);
+private:
+    std::mutex lock; // I think this is right?
+
+    float particleScale;
+
+    glm::vec3 worldPosition;
+    glm::ivec3 chunkGridPosition;
+
+    glm::vec3 worldChunkScale;
+    glm::uvec3 chunkParticleGridSize;
+
+    ParticleData::Manager particleManager;
+
+    GLuint particlesBuffer;
+
+    bool SaveChunkData();
+    bool LoadChunkData();
+};

--- a/systems/ParticlesChunk.h
+++ b/systems/ParticlesChunk.h
@@ -38,7 +38,7 @@ namespace PositionConversion
 }
 
 namespace ChunkConfig {
-    static int maxRaySteps = 200;
+    static int maxRaySteps = 500;
     static bool enableOutlines = false;
 }
 
@@ -53,13 +53,17 @@ public:
     ~ParticlesChunk();
 
     // Update must have a really small workload
-    void Update(float dt);
+    bool Update(float dt);
     // todo: rename this?
     void ProcessNextSimulationStep();
     void Render(GLFWwindow* window, GLuint shaderProgram, GLuint particlesColorsBuffer, GLuint VAO);
 
     // If the chunk has a lock on it's data, this will block until it's done
     bool TryPlaceParticleAt(const glm::ivec3& worldParticlePosition, const ParticleData::DataWrapper& particleDataWraper);
+
+    glm::vec3 getChunkDistanceFrom(const glm::ivec3& chunkPos);
+
+    glm::ivec3 getChunkWorldPosition();
 private:
     std::mutex lock; // I think this is right?
 

--- a/systems/ParticlesChunk.h
+++ b/systems/ParticlesChunk.h
@@ -38,7 +38,7 @@ namespace PositionConversion
 }
 
 namespace ChunkConfig {
-    static int maxRaySteps = 500;
+    static int maxRaySteps = 300;
     static bool enableOutlines = false;
 }
 

--- a/systems/ParticlesChunk.h
+++ b/systems/ParticlesChunk.h
@@ -67,6 +67,8 @@ public:
 private:
     std::mutex lock; // I think this is right?
 
+    std::jthread simulationThread;
+
     float particleScale;
 
     glm::vec3 worldPosition;

--- a/systems/Shapes.h
+++ b/systems/Shapes.h
@@ -1,0 +1,73 @@
+//
+// Created by jonah on 9/7/2024.
+//
+
+#pragma once
+#include <GLFW/glfw3.h>
+
+namespace Shapes::Cube {
+    constexpr float cubeVertices[] = {
+        // Front face
+        -0.5f, -0.5f,  0.5f,  // 0
+        0.5f, -0.5f,  0.5f,  // 1
+        0.5f,  0.5f,  0.5f,  // 2
+        -0.5f,  0.5f,  0.5f,  // 3
+
+        // Back face
+        -0.5f, -0.5f, -0.5f,  // 4
+        0.5f, -0.5f, -0.5f,  // 5
+        0.5f,  0.5f, -0.5f,  // 6
+        -0.5f,  0.5f, -0.5f,  // 7
+
+        // Top face
+        0.5f,  0.5f,  0.5f,  // 8
+        -0.5f,  0.5f,  0.5f,  // 9
+        -0.5f,  0.5f, -0.5f,  // 10
+        0.5f,  0.5f, -0.5f,  // 11
+
+        // Bottom face
+        -0.5f, -0.5f,  0.5f,  // 12
+        0.5f, -0.5f,  0.5f,  // 13
+        0.5f, -0.5f, -0.5f,  // 14
+        -0.5f, -0.5f, -0.5f,  // 15
+
+        // Right face
+        0.5f, -0.5f,  0.5f,  // 16
+        0.5f, -0.5f, -0.5f,  // 17
+        0.5f,  0.5f, -0.5f,  // 18
+        0.5f,  0.5f,  0.5f,  // 19
+
+        // Left face
+        -0.5f, -0.5f,  0.5f,  // 20
+        -0.5f, -0.5f, -0.5f,  // 21
+        -0.5f,  0.5f, -0.5f,  // 22
+        -0.5f,  0.5f,  0.5f   // 23
+    };
+
+    // Define the indices for the cube
+    const GLuint indices[] = {
+        // Front face
+        0, 1, 2,
+        2, 3, 0,
+
+        // Back face
+        4, 5, 6,
+        6, 7, 4,
+
+        // Top face
+        8, 9, 10,
+        10, 11, 8,
+
+        // Bottom face
+        12, 13, 14,
+        14, 15, 12,
+
+        // Right face
+        16, 17, 18,
+        18, 19, 16,
+
+        // Left face
+        20, 21, 22,
+        22, 23, 20
+    };
+}


### PR DESCRIPTION
Changes
- Chunks are loaded in a 5x5 around the camera.
- Particle simulation is moved to a thread.

Things to do
- Simulation needs some rethinking.
- Chunks only exist for data saving and loading.
- Data needs to be stored better. Octree maybe?
- Particles should be queued for update, so only queued particles run through simulation.